### PR TITLE
Fix Guard Multiplayer Loop

### DIFF
--- a/Globals/NPC/GuardNPC.cs
+++ b/Globals/NPC/GuardNPC.cs
@@ -109,8 +109,6 @@ namespace Redemption.Globals.NPC
                 if (GuardPoints >= 0)
                 {
                     GuardHit(npc, ref vDmg, ref damage, ref knockback, SoundID.NPCHit4);
-                    if (Main.netMode == NetmodeID.MultiplayerClient)
-                        NetMessage.SendData(MessageID.DamageNPC, -1, -1, null, npc.whoAmI, (float)damage, knockback, hitDirection, 0, 0, 0);
                     if (GuardPoints >= 0)
                         return vDmg;
                 }
@@ -125,8 +123,6 @@ namespace Redemption.Globals.NPC
                 if (GuardPoints >= 0)
                 {
                     GuardHit(npc, ref vDmg, ref damage, ref knockback, SoundID.NPCHit4);
-                    if (Main.netMode == NetmodeID.MultiplayerClient)
-                        NetMessage.SendData(MessageID.DamageNPC, -1, -1, null, npc.whoAmI, (float)damage, knockback, hitDirection, 0, 0, 0);
                     if (GuardPoints >= 0)
                         return vDmg;
                 }
@@ -138,8 +134,6 @@ namespace Redemption.Globals.NPC
                 if (GuardPoints >= 0)
                 {
                     GuardHit(npc, ref vDmg, ref damage, ref knockback, SoundID.NPCHit4);
-                    if (Main.netMode == NetmodeID.MultiplayerClient)
-                        NetMessage.SendData(MessageID.DamageNPC, -1, -1, null, npc.whoAmI, (float)damage, knockback, hitDirection, 0, 0, 0);
                     if (GuardPoints >= 0)
                         return vDmg;
                 }
@@ -150,8 +144,6 @@ namespace Redemption.Globals.NPC
                 if (GuardPoints >= 0)
                 {
                     GuardHit(npc, ref vDmg, ref damage, ref knockback, SoundID.NPCHit4);
-                    if (Main.netMode == NetmodeID.MultiplayerClient)
-                        NetMessage.SendData(MessageID.DamageNPC, -1, -1, null, npc.whoAmI, (float)damage, knockback, hitDirection, 0, 0, 0);
                     if (GuardPoints >= 0)
                         return vDmg;
                 }
@@ -162,8 +154,6 @@ namespace Redemption.Globals.NPC
                 if (GuardPoints >= 0)
                 {
                     GuardHit(npc, ref vDmg, ref damage, ref knockback, SoundID.NPCHit4, 0.5f);
-                    if (Main.netMode == NetmodeID.MultiplayerClient)
-                        NetMessage.SendData(MessageID.DamageNPC, -1, -1, null, npc.whoAmI, (float)damage, knockback, hitDirection, 0, 0, 0);
                     if (GuardPoints >= 0)
                         return vDmg;
                 }
@@ -174,8 +164,6 @@ namespace Redemption.Globals.NPC
                 if (GuardPoints >= 0)
                 {
                     GuardHit(npc, ref vDmg, ref damage, ref knockback, SoundID.NPCHit4, 0.2f);
-                    if (Main.netMode == NetmodeID.MultiplayerClient)
-                        NetMessage.SendData(MessageID.DamageNPC, -1, -1, null, npc.whoAmI, (float)damage, knockback, hitDirection, 0, 0, 0);
                     if (GuardPoints >= 0)
                         return vDmg;
                 }

--- a/NPCs/Bosses/ADD/Akka.cs
+++ b/NPCs/Bosses/ADD/Akka.cs
@@ -145,8 +145,6 @@ namespace Redemption.NPCs.Bosses.ADD
             if (NPC.RedemptionGuard().GuardPoints >= 0)
             {
                 NPC.RedemptionGuard().GuardHit(NPC, ref vDmg, ref damage, ref knockback, SoundID.Dig with { Pitch = -.1f });
-                if (Main.netMode == NetmodeID.MultiplayerClient)
-                    NetMessage.SendData(MessageID.DamageNPC, -1, -1, null, NPC.whoAmI, (float)damage, knockback, hitDirection, 0, 0, 0);
                 if (NPC.RedemptionGuard().GuardPoints >= 0)
                     return vDmg;
             }

--- a/NPCs/Bosses/ADD/Ukko.cs
+++ b/NPCs/Bosses/ADD/Ukko.cs
@@ -157,8 +157,6 @@ namespace Redemption.NPCs.Bosses.ADD
             if (NPC.RedemptionGuard().GuardPoints >= 0)
             {
                 NPC.RedemptionGuard().GuardHit(NPC, ref vDmg, ref damage, ref knockback, SoundID.DD2_WitherBeastCrystalImpact);
-                if (Main.netMode == NetmodeID.MultiplayerClient)
-                    NetMessage.SendData(MessageID.DamageNPC, -1, -1, null, NPC.whoAmI, (float)damage, knockback, hitDirection, 0, 0, 0);
                 if (NPC.RedemptionGuard().GuardPoints >= 0)
                     return vDmg;
             }

--- a/NPCs/Friendly/WraithSlayer_Samurai.cs
+++ b/NPCs/Friendly/WraithSlayer_Samurai.cs
@@ -100,8 +100,6 @@ namespace Redemption.NPCs.Friendly
             if (NPC.RedemptionGuard().GuardPoints >= 0)
             {
                 NPC.RedemptionGuard().GuardHit(NPC, ref vDmg, ref damage, ref knockback, SoundID.NPCHit4);
-                if (Main.netMode == NetmodeID.MultiplayerClient)
-                    NetMessage.SendData(MessageID.DamageNPC, -1, -1, null, NPC.whoAmI, (float)damage, knockback, hitDirection, 0, 0, 0);
                 if (NPC.RedemptionGuard().GuardPoints >= 0)
                     return vDmg;
             }

--- a/NPCs/Lab/Janitor/JanitorBot.cs
+++ b/NPCs/Lab/Janitor/JanitorBot.cs
@@ -101,8 +101,6 @@ namespace Redemption.NPCs.Lab.Janitor
             if (AIState is not ActionState.Slip && NPC.RedemptionGuard().GuardPoints >= 0)
             {
                 NPC.RedemptionGuard().GuardHit(NPC, ref vDmg, ref damage, ref knockback, SoundID.NPCHit4);
-                if (Main.netMode == NetmodeID.MultiplayerClient)
-                    NetMessage.SendData(MessageID.DamageNPC, -1, -1, null, NPC.whoAmI, (float)damage, knockback, hitDirection, 0, 0, 0);
                 if (NPC.RedemptionGuard().GuardPoints >= 0)
                     return vDmg;
             }

--- a/NPCs/Lab/MACE/MACEProject.cs
+++ b/NPCs/Lab/MACE/MACEProject.cs
@@ -147,8 +147,6 @@ namespace Redemption.NPCs.Lab.MACE
             if (NPC.RedemptionGuard().GuardPoints >= 0)
             {
                 NPC.RedemptionGuard().GuardHit(NPC, ref vDmg, ref damage, ref knockback, SoundID.NPCHit4);
-                if (Main.netMode == NetmodeID.MultiplayerClient)
-                    NetMessage.SendData(MessageID.DamageNPC, -1, -1, null, NPC.whoAmI, (float)damage, knockback, hitDirection, 0, 0, 0);
                 if (NPC.RedemptionGuard().GuardPoints >= 0)
                     return vDmg;
             }

--- a/NPCs/PreHM/AncientGladestoneGolem.cs
+++ b/NPCs/PreHM/AncientGladestoneGolem.cs
@@ -109,8 +109,6 @@ namespace Redemption.NPCs.PreHM
             if (NPC.RedemptionGuard().GuardPoints >= 0)
             {
                 NPC.RedemptionGuard().GuardHit(NPC, ref vDmg, ref damage, ref knockback, SoundID.DD2_WitherBeastCrystalImpact, .1f);
-                if (Main.netMode == NetmodeID.MultiplayerClient)
-                    NetMessage.SendData(MessageID.DamageNPC, -1, -1, null, NPC.whoAmI, (float)damage, knockback, hitDirection, 0, 0, 0);
                 if (NPC.RedemptionGuard().GuardPoints >= 0)
                     return vDmg;
             }

--- a/NPCs/PreHM/JollyMadman.cs
+++ b/NPCs/PreHM/JollyMadman.cs
@@ -116,8 +116,6 @@ namespace Redemption.NPCs.PreHM
             if (NPC.RedemptionGuard().GuardPoints >= 0)
             {
                 NPC.RedemptionGuard().GuardHit(NPC, ref vDmg, ref damage, ref knockback, SoundID.NPCHit4);
-                if (Main.netMode == NetmodeID.MultiplayerClient)
-                    NetMessage.SendData(MessageID.DamageNPC, -1, -1, null, NPC.whoAmI, (float)damage, knockback, hitDirection, 0, 0, 0);
                 if (NPC.RedemptionGuard().GuardPoints >= 0)
                     return vDmg;
             }

--- a/NPCs/PreHM/SkeletonNoble.cs
+++ b/NPCs/PreHM/SkeletonNoble.cs
@@ -129,8 +129,6 @@ namespace Redemption.NPCs.PreHM
             if (NPC.RedemptionGuard().GuardPoints >= 0)
             {
                 NPC.RedemptionGuard().GuardHit(NPC, ref vDmg, ref damage, ref knockback, SoundID.NPCHit4);
-                if (Main.netMode == NetmodeID.MultiplayerClient)
-                    NetMessage.SendData(MessageID.DamageNPC, -1, -1, null, NPC.whoAmI, (float)damage, knockback, hitDirection, 0, 0, 0);
                 if (NPC.RedemptionGuard().GuardPoints >= 0)
                     return vDmg;
             }

--- a/NPCs/PreHM/SkeletonWarden.cs
+++ b/NPCs/PreHM/SkeletonWarden.cs
@@ -129,8 +129,6 @@ namespace Redemption.NPCs.PreHM
             if (blocked && NPC.RedemptionGuard().GuardPoints >= 0)
             {
                 NPC.RedemptionGuard().GuardHit(NPC, ref vDmg, ref damage, ref knockback, SoundID.Dig, 0.1f, true);
-                if (Main.netMode == NetmodeID.MultiplayerClient)
-                    NetMessage.SendData(MessageID.DamageNPC, -1, -1, null, NPC.whoAmI, (float)damage, knockback, hitDirection, 0, 0, 0);
                 blocked = false;
                 if (NPC.RedemptionGuard().GuardPoints >= 0)
                     return vDmg;


### PR DESCRIPTION
* Fixed a bug where hitting an enemy with a guard on a server with 2+ players would infinitely loop the guard hit effect and sound.

From SoA's #dev-coding on the changes:
> Think I found it. The `SendData` in `StrikeNPC` ends up sending a second message (`StrikeNPC` already sends it), which calls `StrikeNPC` on the other client, which sends the message back, etc. etc.
> I removed the `SendData` and it no longer looped. It shouldn't have any harmful effects since `StrikeNPC` already sends a message.